### PR TITLE
FIX Issue #4 "Hide passed tests" checkbox not hidding passed tests

### DIFF
--- a/qunit.css
+++ b/qunit.css
@@ -203,6 +203,21 @@ body {
 	color: #6c6;
 }
 
+#qunit-tests.hidepass {
+	position: relative;
+}
+
+#qunit-tests.hidepass li.running,
+#qunit-tests.hidepass li.pass:not(.todo) {
+	visibility: hidden;
+	position: absolute;
+	width:   0;
+	height:  0;
+	padding: 0;
+	border:  0;
+	margin:  0;
+}
+
 /* Test assertion output */
 
 .qunit-collapsed {


### PR DESCRIPTION
When I checked "Hide passed tests" checkbox, nothing happen.

Should hide all passed test on click.